### PR TITLE
Pull the artifact generator from public NPM repo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,7 @@ jobs:
           uses: actions/setup-node@v1
           with:
             node-version: '12.12.0'
-            registry-url: https://npm.pkg.github.com/
+            registry-url: https://registry.npmjs.com/
             scope: '@inrupt'
         # The following step sets up Maven.
         - name: Set up JDK 11
@@ -54,20 +54,10 @@ jobs:
           id: generator-version-common
           with:
             vocab-config-path: ${{ matrix.vocab }}
-
-        # Installs the Artifact Generator from its GitHub package.
-        # The package is renamed in order to enable having different versions
-        # side-by-side.
-        - name: Install Artifact Generator
-          run: npm install artifact-generator${{steps.generator-version-common.outputs.vocab-generator-version}}@npm:@inrupt/artifact-generator@${{steps.generator-version-common.outputs.vocab-generator-version}} --registry https://npm.pkg.github.com/inrupt
-          env:
-            NODE_AUTH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         # Note: This only pushes to Cloudsmith (not npm), because it does not
         # increment the version number, which is fine for Maven SNAPSHOT
         # versions.
-        - run: node node_modules/artifact-generator${{steps.generator-version-common.outputs.vocab-generator-version}}/index.js generate -l ${{ matrix.vocab }} --noprompt -p cloudsmith
-          env:
-              NODE_AUTH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        - run: npx @inrupt/artifact-generator@${{steps.generator-version-common.outputs.vocab-generator-version}} generate -l ${{ matrix.vocab }} --noprompt -p cloudsmith
         - name: Upload log for debug
           # Only upload if the previous step failed.
           if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           uses: actions/setup-node@v1
           with:
             node-version: '12.12.0'
-            registry-url: https://npm.pkg.github.com/
+            registry-url: https://registry.npmjs.com/
             scope: '@inrupt'
         # The following step sets up Maven.
         - name: Set up JDK 11
@@ -51,14 +51,4 @@ jobs:
           id: generator-version-common
           with:
             vocab-config-path: ${{ matrix.vocab }}
-
-        # Installs the Artifact Generator from its GitHub package.
-        # The package is renamed in order to enable having different versions
-        # side-by-side.
-        - name: Install Artifact Generator
-          run: npm install artifact-generator${{steps.generator-version-common.outputs.vocab-generator-version}}@npm:@inrupt/artifact-generator@${{steps.generator-version-common.outputs.vocab-generator-version}} --registry https://npm.pkg.github.com/inrupt
-          env:
-            NODE_AUTH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        - run: node node_modules/artifact-generator${{steps.generator-version-common.outputs.vocab-generator-version}}/index.js generate -l ${{ matrix.vocab }} --noprompt
-        env:
-            NODE_AUTH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        - run: npx @inrupt/artifact-generator@${{steps.generator-version-common.outputs.vocab-generator-version}} generate -l ${{ matrix.vocab }} --noprompt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '12.12.0'
-        registry-url: https://npm.pkg.github.com/
+        registry-url: https://registry.npmjs.com/
         scope: '@inrupt'
     # The following action is defined in the current repository.
     # It reads the expected Artifact Generator version from the YAML file.
@@ -36,26 +36,10 @@ jobs:
       id: generator-version-common
       with: 
         vocab-config-path: ${{ matrix.vocab }}
-    # Installs the artifact generator from its GitHub package.
-    # The package is renamed in order to enable having different versions
-    # side-by-side.
-    - name: Generator installation
-      run: npm install artifact-generator${{steps.generator-version-common.outputs.vocab-generator-version}}@npm:@inrupt/artifact-generator@${{steps.generator-version-common.outputs.vocab-generator-version}} --registry https://npm.pkg.github.com/inrupt
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-    - name: npm cleanup
-      run: rm /home/runner/work/_temp/.npmrc
-    # Re-initializes npm to publish to NPMJS.
-    - name: Node setup
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.12.0'
-        registry-url: https://registry.npmjs.com/
-        scope: '@inrupt'
     # Use the generator to generate and publish the npm package.
     # Maven packages are published by the CD script, and do not need to be
     # published again on release.
     - name: Generation and publication
-      run: node node_modules/artifact-generator${{steps.generator-version-common.outputs.vocab-generator-version}}/index.js generate -l ${{ matrix.vocab }} -p npmPublic --noprompt
+      run: npx @inrupt/artifact-generator@${{steps.generator-version-common.outputs.vocab-generator-version}} generate -l ${{ matrix.vocab }} -p npmPublic --noprompt
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The CI no longer pulls the artifact generator from the private GH
registry, but rather from the public NPM one.
