### PR TITLE
StringLiteral now generates TypeScript instead of JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ configuration files contained in this repository.
 
 ## Unreleased
 
+- Updated the StringLiteral artifacts to generate TypeScript instead of
+  JavaScript.
+- Configure the required Typescript packaging files consistently. 
+
 ## v1.0.0 2021-08-11
+
 - Release to open source.
 
 ## v0.0.28 2021-08-10

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ This repository contains Artifact Generator configuration files for many
 bundles of related vocabularies (each configured in its own sub-directory from
 the root of this repository).
 
-**Note:** Below we provide links to the default JavaScript artifacts that Inrupt
+**Note:** Below we provide links to the default TypeScript artifacts that Inrupt
 publishes to `npmjs.org` (which define individual vocabulary terms using String
-literals), but in fact we also publish many more artifacts that are more
+literals). In fact we also publish many more artifacts that are more
 specialized for working with RDF too (e.g., we publish artifacts where the
 vocabulary terms are typed as `IRI` from your favorite RDF library, such as in
 Java from [RDF4J](https://rdf4j.org/javadoc/latest/index.html?org/eclipse/rdf4j/model/IRI.html),
@@ -57,7 +57,7 @@ or as `NamedNode` in JavaScript with [RDF/JS](https://rdf.js.org/data-model-spec
    Within Inrupt we use a number of bundles of vocabularies - for example, we
    have a bundle of Glossaries that we maintain as RDF vocabularies; we have a
    bundle for Unit Testing terms; we have a bundle for Inrupt Services; we
-   have a bundle for UI components, etc.
+   have a bundle for UI components; etc.
    
    Of all these bundles, the 'Core' bundle contains vocabularies commonly used
    right across Inrupt:
@@ -69,8 +69,8 @@ or as `NamedNode` in JavaScript with [RDF/JS](https://rdf.js.org/data-model-spec
 To see how and where these bundles are generated, packaged, and published,
 you'll need to look at the configuration files themselves (i.e., the YAML
 files) in each of the respective directories (since different artifacts can be
-generated for different programming languages, and that depend on multiple
-different underlying RDF libraries, and can be published to multiple
+generated for different programming languages, and they can each depend on
+multiple different underlying RDF libraries, and can be published to multiple
 repositories - in other words, the entire generation process is extremely
 configurable and flexible!).
 

--- a/common-rdf/vocab-common-rdf.yml
+++ b/common-rdf/vocab-common-rdf.yml
@@ -22,8 +22,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates:
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -201,24 +200,26 @@ artifactToGenerate:
             id: cloudsmith-development
             url: https://maven.cloudsmith.io/inrupt/sdk-development/
 
-  # This is the configuration of the DEFAULT JavaScript artifact - i.e. where
+  # This is the configuration of the DEFAULT TypeScript artifact - i.e. where
   # the name of the generated npm module does not contain details of it's
   # dependencies (e.g. whether it provides VocabTerm constants or just string
   # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript
+    sourceFileExtension: ts
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabCommon"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -229,14 +230,13 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
@@ -245,14 +245,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -284,14 +285,15 @@ artifactToGenerate:
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -329,9 +331,9 @@ artifactToGenerate:
 # RDF/JS interface DataFactory type).
 #
 #  - programmingLanguage: TypeScript
-#    artifactVersion: "1.0.0"
+#    artifactVersion: "1.0.1"
 #    artifactDirectoryName: TypeScript-rdfjs-Base
-#    templateInternal: rdfLibraryDependent/typescript/rdfjsBase/vocab.hbs
+#    templateInternal: rdfLibraryDependent/typescript/rdfjsBase-DataModel/vocab.hbs
 #    sourceFileExtension: ts
 #    artifactSuffix: -rdfjs-base
 #    packaging:
@@ -341,8 +343,6 @@ artifactToGenerate:
 #
 #        typescriptVersion: "^4.1.3"
 #        rdfjsImplVersion: "^1.2.0"
-#        rdfjsNamespaceVersion: "^1.1.0"
-#        rdfjsNamespaceTypesVersion: "^1.1.1"
 #        rollupVersion: "^2.36.1"
 #        rollupTypescriptPluginVersion: "^0.29.0"
 #        rollupCommonjsPluginVersion: "^17.0.0"
@@ -355,7 +355,7 @@ artifactToGenerate:
 #          - key: "npmPublic"
 #            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
 #        packagingTemplates:
-#          - templateInternal: rdfLibraryDependent/typescript/rdfjs/package.hbs
+#          - templateInternal: rdfLibraryDependent/typescript/rdfjsBase-DataModel/package.hbs
 #            fileName: package.json
 #          - templateInternal: generic/typescript/index.hbs
 #            fileName: index.ts
@@ -364,14 +364,16 @@ artifactToGenerate:
 #          - templateInternal: generic/typescript/rollup.config.hbs
 #            fileName: rollup.config.js
 #
+#
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -rdfjs-rdfdatafactory
 
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -402,21 +404,23 @@ artifactToGenerate:
             fileName: rollup.config.js
 
 
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript-StringLiteral
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript-StringLiteral
+    sourceFileExtension: ts
     artifactSuffix: -stringliteral
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabCommon"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -427,15 +431,15 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
+
 
 vocabList:
 #

--- a/inrupt-rdf/ClientApplication/vocab-inrupt-client-application.yml
+++ b/inrupt-rdf/ClientApplication/vocab-inrupt-client-application.yml
@@ -15,8 +15,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates:
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -70,14 +69,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -109,14 +109,15 @@ artifactToGenerate:
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:

--- a/inrupt-rdf/Core/vocab-inrupt-core.yml
+++ b/inrupt-rdf/Core/vocab-inrupt-core.yml
@@ -21,8 +21,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates:
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -75,24 +74,26 @@ artifactToGenerate:
             url: https://maven.cloudsmith.io/inrupt/sdk-development/
 
 
-  # This is the configuration of the DEFAULT JavaScript artifact - i.e. where
+  # This is the configuration of the DEFAULT TypeScript artifact - i.e. where
   # the name of the generated npm module does not contain details of it's
   # dependencies (e.g. whether it provides VocabTerm constants or just string
   # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript
+    sourceFileExtension: ts
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptCore"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -103,14 +104,13 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
@@ -119,14 +119,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -158,14 +159,15 @@ artifactToGenerate:
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -197,13 +199,14 @@ artifactToGenerate:
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -rdfjs-rdfdatafactory
 
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -234,21 +237,23 @@ artifactToGenerate:
             fileName: rollup.config.js
 
 
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript-StringLiteral
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript-StringLiteral
+    sourceFileExtension: ts
     artifactSuffix: -stringliteral
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptCore"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -259,14 +264,13 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 

--- a/inrupt-rdf/Glossary/vocab-inrupt-glossary.yml
+++ b/inrupt-rdf/Glossary/vocab-inrupt-glossary.yml
@@ -15,8 +15,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates: 
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -70,24 +69,26 @@ artifactToGenerate:
         url: https://maven.cloudsmith.io/inrupt/sdk-development/
       
 
-  # This is the configuration of the DEFAULT JavaScript artifact - i.e. where
+  # This is the configuration of the DEFAULT TypeScript artifact - i.e. where
   # the name of the generated npm module does not contain details of it's
   # dependencies (e.g. whether it provides VocabTerm constants or just string
   # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript
+    sourceFileExtension: ts
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptGlossary"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -98,32 +99,33 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript-StringLiteral
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript-StringLiteral
+    sourceFileExtension: ts
     artifactSuffix: -stringliteral
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptGlossary"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -134,14 +136,13 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
@@ -150,14 +151,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -190,14 +192,15 @@ artifactToGenerate:
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:

--- a/inrupt-rdf/Service/vocab-inrupt-service.yml
+++ b/inrupt-rdf/Service/vocab-inrupt-service.yml
@@ -15,8 +15,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates:
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -70,14 +69,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -86,8 +86,6 @@ artifactToGenerate:
         bundleName: "VocabInruptService"
 
         typescriptVersion: "^4.1.3"
-        rdfjsNamespaceVersion: "^1.1.0"
-        rdfjsNamespaceTypesVersion: "^1.1.1"
         rollupVersion: "^2.36.1"
         rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
@@ -110,14 +108,15 @@ artifactToGenerate:
             fileName: rollup.config.js  
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -126,8 +125,6 @@ artifactToGenerate:
         bundleName: "VocabInruptService"
 
         typescriptVersion: "^4.1.3"
-        rdfjsNamespaceVersion: "^1.1.0"
-        rdfjsNamespaceTypesVersion: "^1.1.1"
         rollupVersion: "^2.36.1"
         rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
@@ -150,13 +147,14 @@ artifactToGenerate:
             fileName: rollup.config.js
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -rdfjs-rdfdatafactory
 
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:

--- a/inrupt-rdf/Test/vocab-inrupt-test.yml
+++ b/inrupt-rdf/Test/vocab-inrupt-test.yml
@@ -15,8 +15,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates:
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -69,24 +68,26 @@ artifactToGenerate:
         id: cloudsmith-development
         url: https://maven.cloudsmith.io/inrupt/sdk-development/
 
-  # This is the configuration of the DEFAULT JavaScript artifact - i.e. where
+  # This is the configuration of the DEFAULT TypeScript artifact - i.e. where
   # the name of the generated npm module does not contain details of it's
   # dependencies (e.g. whether it provides VocabTerm constants or just string
   # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript
+    sourceFileExtension: ts
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptTest"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -97,29 +98,30 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
+
 
   # This is the configuration of the DEFAULT VocabTerm TypeScript artifact -
   # i.e., where the name of the generated npm module does not contain details
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -128,8 +130,6 @@ artifactToGenerate:
         bundleName: "VocabInruptTest"
 
         typescriptVersion: "^4.1.3"
-        rdfjsNamespaceVersion: "^1.1.0"
-        rdfjsNamespaceTypesVersion: "^1.1.1"
         rollupVersion: "^2.36.1"
         rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
@@ -152,14 +152,15 @@ artifactToGenerate:
             fileName: rollup.config.js
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -168,8 +169,6 @@ artifactToGenerate:
         bundleName: "VocabInruptTest"
 
         typescriptVersion: "^4.1.3"
-        rdfjsNamespaceVersion: "^1.1.0"
-        rdfjsNamespaceTypesVersion: "^1.1.1"
         rollupVersion: "^2.36.1"
         rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
@@ -192,13 +191,14 @@ artifactToGenerate:
             fileName: rollup.config.js
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -rdfjs-rdfdatafactory
 
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -235,9 +235,9 @@ artifactToGenerate:
   # RDF/JS interface DataFactory type).
   #
 #  - programmingLanguage: TypeScript
-#    artifactVersion: "1.0.0"
+#    artifactVersion: "1.0.1"
 #    artifactDirectoryName: TypeScript-rdfjs-base
-#    templateInternal: rdfLibraryDependent/typescript/rdfjsBase/vocab.hbs
+#    templateInternal: rdfLibraryDependent/typescript/rdfjsBase-DataModel/vocab.hbs
 #    sourceFileExtension: ts
 #    artifactSuffix: -rdfjs-base
 #    packaging:
@@ -247,8 +247,6 @@ artifactToGenerate:
 #
 #        typescriptVersion: "^4.1.3"
 #        rdfjsImplVersion: "^1.2.0"
-#        rdfjsNamespaceVersion: "^1.1.0"
-#        rdfjsNamespaceTypesVersion: "^1.1.1"
 #        rollupVersion: "^2.36.1"
 #        rollupTypescriptPluginVersion: "^0.29.0"
 #        rollupCommonjsPluginVersion: "^17.0.0"
@@ -261,7 +259,7 @@ artifactToGenerate:
 #          - key: "npmPublic"
 #            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
 #        packagingTemplates:
-#          - templateInternal: rdfLibraryDependent/typescript/rdfjsBase/package.hbs
+#          - templateInternal: rdfLibraryDependent/typescript/rdfjsBase-DataModel/package.hbs
 #            fileName: package.json
 #          - templateInternal: generic/typescript/index.hbs
 #            fileName: index.ts
@@ -270,21 +268,23 @@ artifactToGenerate:
 #          - templateInternal: generic/typescript/rollup.config.hbs
 #            fileName: rollup.config.js
 
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript-StringLiteral
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript-StringLiteral
+    sourceFileExtension: ts
     artifactSuffix: -stringliteral
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptTest"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -295,15 +295,15 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
+
 
 vocabList:
   - description: Test vocabulary - defines classes and properties for testing (like WebID's, resources, containers, etc.).

--- a/inrupt-rdf/Ui/vocab-inrupt-ui.yml
+++ b/inrupt-rdf/Ui/vocab-inrupt-ui.yml
@@ -10,8 +10,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates: 
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -28,13 +27,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -43,7 +44,6 @@ artifactToGenerate:
         bundleName: "VocabInruptUi"
 
         typescriptVersion: "^4.1.3"
-        rdfjsImplVersion: "^1.0.4"
         rollupVersion: "^2.36.1"
         rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
@@ -68,13 +68,15 @@ artifactToGenerate:
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -83,7 +85,6 @@ artifactToGenerate:
         bundleName: "VocabInruptUi"
 
         typescriptVersion: "^4.1.3"
-        rdfjsImplVersion: "^1.0.4"
         rollupVersion: "^2.36.1"
         rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
@@ -107,24 +108,26 @@ artifactToGenerate:
             fileName: rollup.config.js
 
 
-  # This is the configuration of the DEFAULT JavaScript artifact - i.e. where
+  # This is the configuration of the DEFAULT TypeScript artifact - i.e. where
   # the name of the generated npm module does not contain details of it's
   # dependencies (e.g. whether it provides VocabTerm constants or just string
   # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript
+    sourceFileExtension: ts
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabInruptUi"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -135,61 +138,62 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
-            fileName: rollup.config.js
-
-
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
-
-    artifactDirectoryName: JavaScript-StringLiteral
-    sourceFileExtension: js
-    artifactSuffix: -stringliteral
-
-    templateInternal: stringLiteral/javascript/vocab.hbs
-
-    packaging:
-      - packagingTool: npm
-        npmModuleScope: "@inrupt/"
-        bundleName: "VocabInruptUi"
-
-        rollupVersion: "^2.36.1"
-        rollupCommonjsPluginVersion: "^17.0.0"
-        rollupNodeResolveVersion: "^11.0.1"
-
-        publish:
-          - key: "npmLocal"
-            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
-          # The following command should only run in CI.
-          - key: "npmPublic"
-            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
-        packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
-            fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
+
+    artifactDirectoryName: TypeScript-StringLiteral
+    sourceFileExtension: ts
+    artifactSuffix: -stringliteral
+
+    templateInternal: stringLiteral/typescript/vocab.hbs
+
+    packaging:
+      - packagingTool: npm
+        npmModuleScope: "@inrupt/"
+        bundleName: "VocabInruptUi"
+
+        typescriptVersion: "^4.1.3"
+        rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
+        rollupCommonjsPluginVersion: "^17.0.0"
+        rollupNodeResolveVersion: "^11.0.1"
+
+        publish:
+          - key: "npmLocal"
+            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
+          # The following command should only run in CI.
+          - key: "npmPublic"
+            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
+        packagingTemplates:
+          - templateInternal: stringLiteral/typescript/package.hbs
+            fileName: package.json
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
+            fileName: rollup.config.js
+
+
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -rdfjs-rdfdatafactory
 
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:

--- a/solid-rdf/vocab-solid.yml
+++ b/solid-rdf/vocab-solid.yml
@@ -22,8 +22,7 @@ artifactGeneratorVersion: 1.0.0
 
 versioning:
   type: git
-  # Remove URL until we open-source this repository...
-  # url: https://github.com/inrupt/solid-common-vocab-rdf.git
+  url: https://github.com/inrupt/solid-common-vocab-rdf.git
   versioningTemplates:
     - templateInternal: ".gitignore.hbs"
       fileName: ".gitignore"
@@ -77,6 +76,7 @@ artifactToGenerate:
           - templateInternal: solidCommonVocabDependent/java/rdf4j/pom.hbs
             fileName: pom.xml
 
+
   - programmingLanguage: Java
     artifactVersion: 0.8.2-SNAPSHOT
 
@@ -115,6 +115,7 @@ artifactToGenerate:
         packagingTemplates:
           - templateInternal: rdfLibraryDependent/java/commonsRdfServiceLoader/pom.hbs
             fileName: pom.xml
+
 
   - programmingLanguage: Java
     artifactVersion: 0.8.2-SNAPSHOT
@@ -155,24 +156,27 @@ artifactToGenerate:
           - templateInternal: rdfLibraryDependent/java/commonsRdfSimpleRdf/pom.hbs
             fileName: pom.xml
 
-  # This is the configuration of the DEFAULT JavaScript artifact - i.e. where
+
+  # This is the configuration of the DEFAULT TypeScript artifact - i.e. where
   # the name of the generated npm module does not contain details of it's
   # dependencies (e.g. whether it provides VocabTerm constants or just string
   # literals, or whether it depends on RDF/JS or Jena or RDF Commons, etc.).
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
 
-    artifactDirectoryName: JavaScript
-    sourceFileExtension: js
+    artifactDirectoryName: TypeScript
+    sourceFileExtension: ts
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabSolid"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -183,14 +187,13 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
@@ -199,14 +202,15 @@ artifactToGenerate:
   # of the underlying RDF library dependencies (e.g., whether it depends on
   # RDF/JS or a specific implementation, etc.).
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm
     sourceFileExtension: ts
     artifactSuffix: -vocabterm
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -235,15 +239,17 @@ artifactToGenerate:
           - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
+
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-VocabTerm-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -vocabterm-rdfjs-rdfdatafactory
 
     solidCommonVocabVersion: "^1.0.0"
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: solidCommonVocabDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -272,14 +278,16 @@ artifactToGenerate:
           - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
+
   - programmingLanguage: TypeScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: TypeScript-rdfjs-RdfDataFactory
     sourceFileExtension: ts
     artifactSuffix: -rdfjs-rdfdatafactory
 
-    rdfjsImplVersion: "^1.0.4"
+    rdfjsTypesVersion: "^1.0.1"
+    rdfjsImplVersion: "^1.1.0"
     templateInternal: rdfLibraryDependent/typescript/rdfjsRdfDataFactory/vocab.hbs
 
     packaging:
@@ -309,21 +317,24 @@ artifactToGenerate:
           - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
 
-    artifactDirectoryName: JavaScript-StringLiteral
-    sourceFileExtension: js
+  - programmingLanguage: TypeScript
+    artifactVersion: "1.0.1"
+
+    artifactDirectoryName: TypeScript-StringLiteral
+    sourceFileExtension: ts
     artifactSuffix: -stringliteral
 
-    templateInternal: stringLiteral/javascript/vocab.hbs
+    templateInternal: stringLiteral/typescript/vocab.hbs
 
     packaging:
       - packagingTool: npm
         npmModuleScope: "@inrupt/"
         bundleName: "VocabSolid"
 
+        typescriptVersion: "^4.1.3"
         rollupVersion: "^2.36.1"
+        rollupTypescriptPluginVersion: "^0.29.0"
         rollupCommonjsPluginVersion: "^17.0.0"
         rollupNodeResolveVersion: "^11.0.1"
 
@@ -334,52 +345,18 @@ artifactToGenerate:
           - key: "npmPublic"
             command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
         packagingTemplates:
-          - templateInternal: stringLiteral/javascript/package.hbs
+          - templateInternal: stringLiteral/typescript/package.hbs
             fileName: package.json
-          - templateInternal: generic/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
+          - templateInternal: generic/typescript/index.hbs
+            fileName: index.ts
+          - templateInternal: generic/typescript/tsconfig.hbs
+            fileName: tsconfig.json
+          - templateInternal: generic/typescript/rollup.config.hbs
             fileName: rollup.config.js
 
 
   - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
-
-    artifactDirectoryName: JavaScript-rdfjsBase
-    sourceFileExtension: js
-    artifactSuffix: -rdfjs-base
-
-    rdfjsNamespaceVersion: "^1.1.0"
-    templateInternal: rdfLibraryDependent/javascript/rdfext/vocab.hbs
-
-    packaging:
-      - packagingTool: npm
-        npmModuleScope: "@inrupt/"
-        bundleName: "VocabSolid"
-
-        publish:
-          - key: "npmLocalWeb"
-            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
-          - key: "npmLocal"
-            command: "npm unpublish --force --registry http://localhost:4873/ && npm install --registry http://localhost:4873/ && npm run build && npm publish --registry http://localhost:4873/"
-          - key: "npmPublic"
-            command: "npm install --registry https://registry.npmjs.org/ && npm run build && npm publish --registry https://registry.npmjs.org/ --access public"
-        packagingTemplates:
-          - templateInternal: rdfLibraryDependent/javascript/rdfext/package.hbs
-            fileName: package.json
-          - templateInternal: rdfLibraryDependent/javascript/index.hbs
-            fileName: index.js
-      - packagingTool: rollup
-        packagingDirectory: config
-        packagingTemplates:
-          - templateInternal: generic/javascript/rollup.config.hbs
-            fileName: rollup.config.js
-
-  - programmingLanguage: JavaScript
-    artifactVersion: "1.0.0"
+    artifactVersion: "1.0.1"
 
     artifactDirectoryName: JavaScript-rdflib
     sourceFileExtension: js
@@ -406,6 +383,9 @@ artifactToGenerate:
           - templateInternal: rdfLibraryDependent/javascript/index.hbs
             fileName: index.js
       - packagingTool: rollup
+        # Note: We provide the location of the packaging files here, since in
+        # this case our JavaScript Rollup template happens to expect it's
+        # configuration file in this specific directory.
         packagingDirectory: config
         packagingTemplates:
           - templateInternal: generic/javascript/rollup.config.hbs


### PR DESCRIPTION
# New feature description
Main change was switching StringLiteral generation to TypeScript instead of JavaScript. Also tidied up TS version dependencies to be more consistent, and removed some unused `rdfsjsNamespace` references.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
