### PR TITLE
align term naming convention

### DIFF
--- a/common-rdf/vocab-common-rdf.yml
+++ b/common-rdf/vocab-common-rdf.yml
@@ -896,6 +896,9 @@ vocabList:
 
   - inputResources:
       - http://www.w3.org/ns/locn#
+    # It seems this server is no longer handling 'q' values for media types
+    # properly, so just explicitly ask for only Turtle.
+    vocabAcceptHeaderOverride: "text/turtle"
 
   - inputResources:
       - http://www.w3.org/ns/sosa/

--- a/solid-rdf/CopyOfVocab/solid-data-discovery.ttl
+++ b/solid-rdf/CopyOfVocab/solid-data-discovery.ttl
@@ -111,24 +111,24 @@ solid_dd:storageDescription a rdf:Property, owl:ObjectProperty ;
     rdfs:comment ""@en ;
     rdfs:comment ""@es .
 
-solid_dd:allowedDataModel a rdf:Property, owl:ObjectProperty ;
+solid_dd:storagePathRelative a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy solid_dd:_Ontology ;
-    rdfs:label "Allowed data model"@en ;
-    rdfs:label "Modelo de datos permitido"@es ;
+    rdfs:label "Storage path (relative to...something)"@en ;
+    rdfs:label "Ruta de almacenamiento (relativa a... algo)"@es ;
     rdfs:comment ""@en ;
     rdfs:comment ""@es .
 
-solid_dd:relativeStoragePath a rdf:Property, owl:ObjectProperty ;
+solid_dd:containerPathBase a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy solid_dd:_Ontology ;
-    rdfs:label "Relative storage path"@en ;
-    rdfs:label "Ruta de almacenamiento relativa"@es ;
+    rdfs:label "Container path (base)"@en ;
+    rdfs:label "Ruta del contenedor (base)"@es ;
     rdfs:comment ""@en ;
     rdfs:comment ""@es .
 
-solid_dd:baseContainerPath a rdf:Property, owl:ObjectProperty ;
+solid_dd:authoredBy a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy solid_dd:_Ontology ;
-    rdfs:label "Base container path"@en ;
-    rdfs:label "Ruta del contenedor base"@es ;
+    rdfs:label "Authored by"@en ;
+    rdfs:label "Escrito por"@es ;
     rdfs:comment ""@en ;
     rdfs:comment ""@es .
 
@@ -139,9 +139,9 @@ solid_dd:authoredWith a rdf:Property, owl:ObjectProperty ;
     rdfs:comment ""@en ;
     rdfs:comment ""@es .
 
-solid_dd:authoredBy a rdf:Property, owl:ObjectProperty ;
+solid_dd:allowedDataModel a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy solid_dd:_Ontology ;
-    rdfs:label "Authored by"@en ;
-    rdfs:label "Escrito por"@es ;
+    rdfs:label "Allowed data model"@en ;
+    rdfs:label "Modelo de datos permitido"@es ;
     rdfs:comment ""@en ;
     rdfs:comment ""@es .

--- a/solid-rdf/CopyOfVocab/solid-data-discovery.ttl
+++ b/solid-rdf/CopyOfVocab/solid-data-discovery.ttl
@@ -111,19 +111,19 @@ solid_dd:storageDescription a rdf:Property, owl:ObjectProperty ;
     rdfs:comment "A description of which relative locations applications use to write a given data model"@en ;
     rdfs:comment "Una descripción de qué ubicaciones relativas utilizan las aplicaciones para escribir un modelo de datos dado"@es .
 
+solid_dd:storagePathBase a rdf:Property, owl:ObjectProperty ;
+    rdfs:isDefinedBy solid_dd:_Ontology ;
+    rdfs:label "Storage path (base)"@en ;
+    rdfs:label "Ruta de almacenamiento (base)"@es ;
+    rdfs:comment "The base path to storage, as specified in a user's profile, that apps should use when resolving a relative storage path"@en ;
+    rdfs:comment "La ruta base al almacenamiento, como se especifica en el perfil de un usuario, que las aplicaciones deben usar al resolver una ruta de almacenamiento relativa"@es .
+
 solid_dd:storagePathRelative a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy solid_dd:_Ontology ;
     rdfs:label "Storage path (relative)"@en ;
     rdfs:label "Ruta de almacenamiento (relativa)"@es ;
     rdfs:comment "Storage path relative to the base container path"@en ;
     rdfs:comment "Ruta de almacenamiento relativa a la base del contenedor"@es .
-
-solid_dd:containerPathBase a rdf:Property, owl:ObjectProperty ;
-    rdfs:isDefinedBy solid_dd:_Ontology ;
-    rdfs:label "Container path (base)"@en ;
-    rdfs:label "Ruta del contenedor (base)"@es ;
-    rdfs:comment "The base container path, as specified in a user's profile, that apps should use when resolving a relative storage path"@en ;
-    rdfs:comment "La ruta de acceso al contenedor base (proporcionada por el usuario) que la aplicación debe usar al resolver una ruta de almacenamiento relativa"@es .
 
 solid_dd:authoredWith a rdf:Property, owl:ObjectProperty ;
     rdfs:isDefinedBy solid_dd:_Ontology ;


### PR DESCRIPTION
Renamed terms to all be consistent, and using left-justification based on 'kind' of thing (i.e., 'storage' or 'container') as opposed to 'base'-ness or 'relative'-ness.
(Reordered some of the terms too, just to keep a more logical flow when reading the vocab from top to bottom - results in a weird-looking diff for review, i.e., where it looks like some terms were renamed when in fact they were just moved in the file.)