### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,package-lock.json,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,5 +2,6 @@
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = .git*,package-lock.json,.codespellrc
 check-hidden = true
-# ignore-regex = 
+# ignore non-english localizations, or symbols with umlauts etc, parts of URLs
+ignore-regex = .*"@\S+(?<!@en)|.*([úáüé]|Dienstleistungen|Seriennummer|Haarschnitt|puramente|en (una|tus)| de los |ser completamente|Par exemple).*|https?://\S+|DELETEing|nameAndPrefixOverride: ore
 # ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Annotate locations with typos
+      - name: Annotate locations with typos in the GH PR
         uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/common-rdf/CopyOfVocab/inrupt-foaf.ttl
+++ b/common-rdf/CopyOfVocab/inrupt-foaf.ttl
@@ -64,7 +64,7 @@ foaf:Image a owl:Class, rdfs:Class;
     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing";
     rdfs:subClassOf foaf:Document.
 foaf:LabelProperty a owl:Class, rdfs:Class;
-    rdfs:comment "A foaf:LabelProperty is any RDF property with texual values that serve as labels.";
+    rdfs:comment "A foaf:LabelProperty is any RDF property with textual values that serve as labels.";
     rdfs:isDefinedBy <http://xmlns.com/foaf/0.1/>;
     rdfs:label "Label Property";
     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable".

--- a/common-rdf/CopyOfVocab/inrupt-void.ttl
+++ b/common-rdf/CopyOfVocab/inrupt-void.ttl
@@ -177,7 +177,7 @@ void:class a rdf:Property, owl:FunctionalProperty;
 
 void:classes a rdf:Property, owl:DatatypeProperty;
     rdfs:label "classes";
-    rdfs:comment "The total number of distinct classes in a void:Dataset. In other words, the number of distinct resources occuring as objects of rdf:type triples in the dataset.";
+    rdfs:comment "The total number of distinct classes in a void:Dataset. In other words, the number of distinct resources occurring as objects of rdf:type triples in the dataset.";
     rdfs:domain void:Dataset;
     rdfs:range xsd:integer .
 

--- a/inrupt-rdf/ClientApplication/README.md
+++ b/inrupt-rdf/ClientApplication/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-artifact-generator.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-artifact-generator.ttl
@@ -163,7 +163,7 @@ Note: We may only wish to remove 'some' cookies, and not all - for instance if a
   inrupt_gen:hasSessionInfo a rdf:Property ;
     rdfs:isDefinedBy inrupt_gen: ;
     rdfs:label "Has Session Info"@en ;
-    rdfs:comment """Link to a collection of session informatoin values, intended to be treated as cookie values (i.e.
+    rdfs:comment """Link to a collection of session information values, intended to be treated as cookie values (i.e.
  if set as a property on a ResponseData object returned from a server-side operation, then our Express handler will
  attempt to set cookies for each property contained within the referenced entity."""@en .
 

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
@@ -46,7 +46,7 @@ inrupt_common:_PrefixDeclaration a sh:PrefixDeclaration ;
 # existing vocabs such as SOSA (http://www.w3.org/ns/sosa), SSN
 # (http://www.w3.org/ns/ssn), or SAREF.
 #
-# Note: Schema.org has a 'device' term, but apparently it's been superceded by
+# Note: Schema.org has a 'device' term, but apparently it's been superseded by
 # 'https://schema.org/availableOnDevice' (according to
 # 'https://schema.org/SoftwareApplication').
 #
@@ -115,7 +115,7 @@ inrupt_common:partialIdHint a rdf:Property ;
  overall questionnaire process may aggregate resources for participant
  invitation; the questions being asked; the answers given; the sharing of
  those answers; the anonymization of those answers; the aggregation of those
- answers into an overall dataset; the geneation of an analysis report; etc.).
+ answers into an overall dataset; the generation of an analysis report; etc.).
   For helpful tracking of all these resources, we may choose to use a
  consistent ID as part of the IRI of each constituent resource, but where each
  resource is hosted in a Pod related to that process stakeholder, and

--- a/inrupt-rdf/Core/README.md
+++ b/inrupt-rdf/Core/README.md
@@ -7,4 +7,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Glossary/README.md
+++ b/inrupt-rdf/Glossary/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Playground/ExamplePodModelling/PodBob.trig
+++ b/inrupt-rdf/Playground/ExamplePodModelling/PodBob.trig
@@ -327,7 +327,7 @@ bob-storage: {  # If a quad serialization was asked for in the 'Accept:' header.
   ex:binaryFile <https://pod.provider.example.com/binary/resource/image-GUID> ;
   ex:gpsLat "20.423" ;
   ex:gpsLong "20.423" ;
-  ex:apeture "??" .
+  ex:aperture "??" .
 
 # GET /public/blog/entry-1
 # ...ALL OF THE ABOVE (plus LDP triples for 'ldp:RDFSource')

--- a/inrupt-rdf/Playground/ExamplePodModelling/PodBobSmall.trig
+++ b/inrupt-rdf/Playground/ExamplePodModelling/PodBobSmall.trig
@@ -365,7 +365,7 @@ bob-storage: {  # If a quad serialization was asked for in the 'Accept:' header.
   ex:binaryFile <https://pod.provider.example.com/binary/resource/image-GUID> ;
   ex:gpsLat "20.423" ;
   ex:gpsLong "20.423" ;
-  ex:apeture "??" .
+  ex:aperture "??" .
 
 # GET /public/blog/entry-1
 # ...ALL OF THE ABOVE (plus LDP triples for 'ldp:RDFSource')

--- a/inrupt-rdf/Service/README.md
+++ b/inrupt-rdf/Service/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Test/README.md
+++ b/inrupt-rdf/Test/README.md
@@ -7,4 +7,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Ui/README.md
+++ b/inrupt-rdf/Ui/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/solid-rdf/Extension/solid-inrupt-ext.ttl
+++ b/solid-rdf/Extension/solid-inrupt-ext.ttl
@@ -19,7 +19,7 @@ prefix solid_inrupt_ext: <https://w3id.org/inrupt/vocab/extension/solid#>
 # vocabularies, specifically to add extra features, such as multilingual
 # values for labels and comments.
 #
-# So we very deliberately re-use the underlying vocab's namespace, but use our
+# So we very deliberately reuse the underlying vocab's namespace, but use our
 # own prefix to try and differentiate.
 #
 solid_inrupt_ext: a inrupt_gen:OntologyExtension ;

--- a/solid-rdf/Extension/solid-oidc-inrupt-ext.ttl
+++ b/solid-rdf/Extension/solid-oidc-inrupt-ext.ttl
@@ -19,7 +19,7 @@ prefix solid_oidc_inrupt_ext: <https://w3id.org/inrupt/vocab/extension/solid_oid
 # vocabularies, specifically to add extra features, such as multilingual
 # values for labels and comments.
 #
-# So we very deliberately re-use the underlying vocab's namespace, but use our
+# So we very deliberately reuse the underlying vocab's namespace, but use our
 # own prefix to try and differentiate.
 #
 solid_oidc_inrupt_ext: a inrupt_gen:OntologyExtension ;

--- a/solid-rdf/Extension/workspace-inrupt-ext.ttl
+++ b/solid-rdf/Extension/workspace-inrupt-ext.ttl
@@ -16,7 +16,7 @@ prefix ws:       <http://www.w3.org/ns/pim/space#>
 # vocabularies, specifically to add extra features, such as multilingual
 # values for labels and comments.
 #
-# So we very deliberately re-use the underlying vocab's namespace, but use our
+# So we very deliberately reuse the underlying vocab's namespace, but use our
 # own prefix to try and differentiate. 
 #
 prefix inrupt_gen: <https://w3id.org/inrupt/namespace/vocab/tool/artifact_generator/>


### PR DESCRIPTION
@edwardsph in https://github.com/inrupt/solid-common-vocab-rdf/pull/180#issuecomment-2385093556 unintentionally dropped me a challenge which I took -- added ignore regex to ignore present localizations and otherwise do typos checks throughout.  Still not sure if robust enough etc, but as you can see it does catch a good number of typos.

More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.