### PR TITLE
Fix typos found by codespell

### DIFF
--- a/common-rdf/CopyOfVocab/inrupt-foaf.ttl
+++ b/common-rdf/CopyOfVocab/inrupt-foaf.ttl
@@ -64,7 +64,7 @@ foaf:Image a owl:Class, rdfs:Class;
     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "testing";
     rdfs:subClassOf foaf:Document.
 foaf:LabelProperty a owl:Class, rdfs:Class;
-    rdfs:comment "A foaf:LabelProperty is any RDF property with texual values that serve as labels.";
+    rdfs:comment "A foaf:LabelProperty is any RDF property with textual values that serve as labels.";
     rdfs:isDefinedBy <http://xmlns.com/foaf/0.1/>;
     rdfs:label "Label Property";
     <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "unstable".

--- a/common-rdf/CopyOfVocab/inrupt-void.ttl
+++ b/common-rdf/CopyOfVocab/inrupt-void.ttl
@@ -177,7 +177,7 @@ void:class a rdf:Property, owl:FunctionalProperty;
 
 void:classes a rdf:Property, owl:DatatypeProperty;
     rdfs:label "classes";
-    rdfs:comment "The total number of distinct classes in a void:Dataset. In other words, the number of distinct resources occuring as objects of rdf:type triples in the dataset.";
+    rdfs:comment "The total number of distinct classes in a void:Dataset. In other words, the number of distinct resources occurring as objects of rdf:type triples in the dataset.";
     rdfs:domain void:Dataset;
     rdfs:range xsd:integer .
 

--- a/inrupt-rdf/ClientApplication/README.md
+++ b/inrupt-rdf/ClientApplication/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-artifact-generator.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-artifact-generator.ttl
@@ -158,7 +158,7 @@ inrupt_gen:subjectRoot a rdf:Property ;
 Note: We may only wish to remove 'some' cookies, and not all - for instance if an Admin user is logged into a
  registration app, and uses their app to log in a beneficiary, then logging out that beneficiary would require removing
  just that beneficies cookie data, but not the Admin user's cookie data, since they may continue using the app to login
- the next beneficary. Therefore this class can contain just the session info we wish to remove."""@en .
+ the next beneficiary. Therefore this class can contain just the session info we wish to remove."""@en .
 
   inrupt_gen:hasSessionInfo a rdf:Property ;
     rdfs:isDefinedBy inrupt_gen: ;

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-best-practice-core.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-best-practice-core.ttl
@@ -36,7 +36,7 @@ inrupt_bp_core:BestPractice a rdfs:Class ;
     rdfs:label "Best Practice"@en ;
     rdfs:label "Mejores prácticas"@es ;
     rdfs:comment """A Best Practice is a commercial or professional procedure that is accepted or prescribed as being correct or most effective."""@en ;
-    rdfs:comment """Una Buena Práctica es un procedimiento commercial o profesional que se acepta o prescribe como correcto o más efectivo."""@en .
+    rdfs:comment """Una Buena Práctica es un procedimiento comercial o profesional que se acepta o prescribe como correcto o más efectivo."""@es .
 
 inrupt_bp_core:Detail a rdfs:Class ;
     rdfs:isDefinedBy inrupt_bp_core:_Ontology ;

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-best-practice-core.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-best-practice-core.ttl
@@ -36,7 +36,7 @@ inrupt_bp_core:BestPractice a rdfs:Class ;
     rdfs:label "Best Practice"@en ;
     rdfs:label "Mejores prácticas"@es ;
     rdfs:comment """A Best Practice is a commercial or professional procedure that is accepted or prescribed as being correct or most effective."""@en ;
-    rdfs:comment """Una Buena Práctica es un procedimiento comercial o profesional que se acepta o prescribe como correcto o más efectivo."""@en .
+    rdfs:comment """Una Buena Práctica es un procedimiento commercial o profesional que se acepta o prescribe como correcto o más efectivo."""@en .
 
 inrupt_bp_core:Detail a rdfs:Class ;
     rdfs:isDefinedBy inrupt_bp_core:_Ontology ;

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
@@ -172,7 +172,7 @@ inrupt_common:authenticationTokenAsJwt a rdf:Property ;
     rdfs:comment """An authentication token encoded as a JSON Web Token (JWT). This JWT may
  contain not just an access code, but also user account IDs or other information."""@en ;
     rdfs:comment """Un token de autenticación codificado como JSON Web Token (JWT). Este JWT puede
- contener no solo un código de acceso, sino también ID de cuenta de usuario u otra información."""@es .
+ container no solo un código de acceso, sino también ID de cuenta de usuario u otra información."""@es .
 
 inrupt_common:accessTokenAsString a rdf:Property ;
     rdfs:isDefinedBy inrupt_common: ;

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-common.ttl
@@ -172,7 +172,7 @@ inrupt_common:authenticationTokenAsJwt a rdf:Property ;
     rdfs:comment """An authentication token encoded as a JSON Web Token (JWT). This JWT may
  contain not just an access code, but also user account IDs or other information."""@en ;
     rdfs:comment """Un token de autenticación codificado como JSON Web Token (JWT). Este JWT puede
- container no solo un código de acceso, sino también ID de cuenta de usuario u otra información."""@es .
+ contener no solo un código de acceso, sino también ID de cuenta de usuario u otra información."""@es .
 
 inrupt_common:accessTokenAsString a rdf:Property ;
     rdfs:isDefinedBy inrupt_common: ;

--- a/inrupt-rdf/Core/CopyOfVocab/inrupt-consent.ttl
+++ b/inrupt-rdf/Core/CopyOfVocab/inrupt-consent.ttl
@@ -100,7 +100,7 @@ inrupt_consent:latestConsentInstance a rdf:Property ;
 inrupt_consent:ConsentContainer a rdfs:Class ;
     rdfs:isDefinedBy inrupt_consent: ;
     rdfs:label "Consent Container"@en ;
-    rdfs:comment """Consent container (which is a collection of Consent occurances)."""@en .
+    rdfs:comment """Consent container (which is a collection of Consent occurrences)."""@en .
 
 inrupt_consent:hasConsentContainer a rdf:Property ;
     rdfs:isDefinedBy inrupt_consent: ;

--- a/inrupt-rdf/Core/README.md
+++ b/inrupt-rdf/Core/README.md
@@ -7,4 +7,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Glossary/README.md
+++ b/inrupt-rdf/Glossary/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Playground/ExamplePodModelling/PodBob.trig
+++ b/inrupt-rdf/Playground/ExamplePodModelling/PodBob.trig
@@ -327,7 +327,7 @@ bob-storage: {  # If a quad serialization was asked for in the 'Accept:' header.
   ex:binaryFile <https://pod.provider.example.com/binary/resource/image-GUID> ;
   ex:gpsLat "20.423" ;
   ex:gpsLong "20.423" ;
-  ex:apeture "??" .
+  ex:aperture "??" .
 
 # GET /public/blog/entry-1
 # ...ALL OF THE ABOVE (plus LDP triples for 'ldp:RDFSource')

--- a/inrupt-rdf/Playground/ExamplePodModelling/PodBobSmall.trig
+++ b/inrupt-rdf/Playground/ExamplePodModelling/PodBobSmall.trig
@@ -365,7 +365,7 @@ bob-storage: {  # If a quad serialization was asked for in the 'Accept:' header.
   ex:binaryFile <https://pod.provider.example.com/binary/resource/image-GUID> ;
   ex:gpsLat "20.423" ;
   ex:gpsLong "20.423" ;
-  ex:apeture "??" .
+  ex:aperture "??" .
 
 # GET /public/blog/entry-1
 # ...ALL OF THE ABOVE (plus LDP triples for 'ldp:RDFSource')

--- a/inrupt-rdf/Playground/Medical/vpp-questionnaire-prem.ttl
+++ b/inrupt-rdf/Playground/Medical/vpp-questionnaire-prem.ttl
@@ -93,7 +93,7 @@ vpp_prem:_sectionNatureOfStay a owl:NamedIndividual, vpp_qcommon:Section ;
 vpp_prem:_questionAdvanceInfoFromReferringPhysicanOnPreparation a owl:NamedIndividual, sur:Question ;
     rdfs:isDefinedBy vpp_prem:_Ontology ;
     rdfs:label
-        "Advance info from referring physican on preparation"@en ,
+        "Advance info from referring physician on preparation"@en ,
         ""@fr ,
         ""@nl ;
     rdfs:comment

--- a/inrupt-rdf/Playground/inrupt-best-practice.ttl
+++ b/inrupt-rdf/Playground/inrupt-best-practice.ttl
@@ -36,7 +36,7 @@ inrupt_bp_core:template_Class a rdfs:Class ;
     rdfs:label "Best Practice"@en ;
     rdfs:label "Mejores prácticas"@es ;
     rdfs:comment """A Best Practice is a commercial or professional procedure that is accepted or prescribed as being correct or most effective."""@en ;
-    rdfs:comment """Una Buena Práctica es un procedimiento comercial o profesional que se acepta o prescribe como correcto o más efectivo."""@en .
+    rdfs:comment """Una Buena Práctica es un procedimiento commercial o profesional que se acepta o prescribe como correcto o más efectivo."""@en .
 
 inrupt_bp_core:template_property a rdf:Property ;
     rdfs:isDefinedBy inrupt_bp_core:_Ontology ;

--- a/inrupt-rdf/Playground/inrupt-best-practice.ttl
+++ b/inrupt-rdf/Playground/inrupt-best-practice.ttl
@@ -36,7 +36,7 @@ inrupt_bp_core:template_Class a rdfs:Class ;
     rdfs:label "Best Practice"@en ;
     rdfs:label "Mejores prácticas"@es ;
     rdfs:comment """A Best Practice is a commercial or professional procedure that is accepted or prescribed as being correct or most effective."""@en ;
-    rdfs:comment """Una Buena Práctica es un procedimiento commercial o profesional que se acepta o prescribe como correcto o más efectivo."""@en .
+    rdfs:comment """Una Buena Práctica es un procedimiento comercial o profesional que se acepta o prescribe como correcto o más efectivo."""@es .
 
 inrupt_bp_core:template_property a rdf:Property ;
     rdfs:isDefinedBy inrupt_bp_core:_Ontology ;

--- a/inrupt-rdf/Service/README.md
+++ b/inrupt-rdf/Service/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Test/README.md
+++ b/inrupt-rdf/Test/README.md
@@ -7,4 +7,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.

--- a/inrupt-rdf/Ui/README.md
+++ b/inrupt-rdf/Ui/README.md
@@ -6,4 +6,4 @@ A vocabulary list file configures the generation, packaging, and publication
 of programming-language artifacts (e.g., Java JARs, JavaScript packages, etc.)
 that bundle together classes for each of the RDF vocabularies listed, whereby
 each class will contain constants for each of the terms (e.g., the RDF
-Classes, Properies and constants) described within an individual vocabulary.
+Classes, Properties and constants) described within an individual vocabulary.


### PR DESCRIPTION
This PR is based on https://github.com/inrupt/solid-common-vocab-rdf/pull/180, provided by https://github.com/yarikoptic.

Here are typos with their counts and introduced fix:

      1 beneficary ==> beneficiary
      1 occurances ==> occurrences
      1 occuring ==> occurring
      1 physican ==> physician
      1 texual ==> textual
      2 apeture ==> aperture
      6 Properies ==> Properties